### PR TITLE
feat: 회원가입시 카카오 우편번호 API 기반 주소 검색 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <title>CarFit - 차량 관리 플랫폼</title>
+    <!-- 카카오 우편번호 API -->
+    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 주요 변경 사항
> 어떤 기능을 추가/수정했는지 간단하고 명확하게 설명해주세요.

- 회원가입 페이지에 카카오 우편번호 API 연동
- 주소 입력 UI/UX 개선


---
## 🛠 작업 상세 내용
| 항목 | 내용 |
|------|------|
| 구현 기능 | 카카오 우편번호 서비스를 통한 주소 검색 및 자동 입력 기능 |
| 추가 패키지 | 카카오 우편번호 API (CDN) |
| 수정한 파일 | `index.html`, `src/views/SignupView.vue` |

### 상세 기능
- 🔍 **주소 찾기 버튼**: 카카오 우편번호 팝업 호출
- 📮 **우편번호 자동 입력**: 주소 선택 시 자동으로 우편번호 입력
- 🏠 **도로명 주소 자동 입력**: 선택한 주소 자동 입력 (읽기 전용)
- 🏢 **상세 주소 직접 입력**: 동/호수 등 상세 정보 입력
- 🎨 **다크모드 지원**: 기존 디자인 시스템과 일관된 스타일 적용
- ♿ **접근성 개선**: 주소 선택 후 자동으로 상세 주소 필드로 포커스 이동

---

## ✅ 체크리스트
- [x] 기능이 정상 동작함
- [x] eslint / prettier 적용됨
- [x] 테스트 또는 콘솔 확인 완료
- [x] PR 설명을 모두 작성함
- [ ] 리뷰어 지정함

---


## 🖼️ 스크린샷 (선택)

| 화면 | 이미지 |
|------|--------|
| After  | <img width="1250" height="1295" alt="image" src="https://github.com/user-attachments/assets/f06c4104-2b49-4eaa-9ee3-122d7f871fc0" /> |

> 이미지 링크는 GitHub에 업로드하거나 issue에 첨부한 이미지 주소를 넣으면 돼요!

---

## 🔗 관련 이슈
- #1 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입에 주소 검색(다음/카카오 우편번호) 추가: ‘주소 찾기’로 우편번호·도로명·지번 자동 입력, 상세주소 입력 시 전체 주소 자동 완성 및 포커스 이동.
- 스타일
  - 페이지 제목을 ‘CarFit - 차량 관리 플랫폼’으로 변경.
  - 주소 입력 UI 개선 및 플레이스홀더/읽기 전용 처리로 사용성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->