### PR TITLE
feat: 소셜 로그인 통합 구현 (카카오, 구글, 네이버)

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from "vue-router";
 import MainView from "../views/MainView.vue";
 import LoginView from "../views/LoginView.vue";
+import LoginRedirectView from "../views/LoginRedirectView.vue";
+import SocialSignupView from "../views/SocialSignupView.vue";
 import SignupView from "../views/SignupView.vue";
 import CommunityWriteView from "../views/CommunityWriteView.vue";
 import CommunityDetailView from "../views/CommunityDetailView.vue";
@@ -22,6 +24,30 @@ const router = createRouter({
       name: "login",
       component: LoginView,
       meta: { requiresAuth: false }, // 인증 불필요
+    },
+    {
+      path: "/oauth/callback/kakao",
+      name: "login-redirect-kakao",
+      component: LoginRedirectView,
+      meta: { requiresAuth: false }, // 인증 불필요
+    },
+    {
+      path: "/oauth/callback/google",
+      name: "login-redirect-google",
+      component: LoginRedirectView,
+      meta: { requiresAuth: false }, // 인증 불필요
+    },
+    {
+      path: "/oauth/callback/naver",
+      name: "login-redirect-naver",
+      component: LoginRedirectView,
+      meta: { requiresAuth: false }, // 인증 불필요
+    },
+    {
+      path: "/social-signup",
+      name: "social-signup",
+      component: SocialSignupView,
+      meta: { requiresAuth: false }, // 인증 불필요 (소셜 로그인 후)
     },
     {
       path: "/signup",

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -29,12 +29,12 @@ export const useAuthStore = defineStore('auth', () => {
         const accessToken = response.data.token
         if (accessToken) {
           setToken(accessToken)
-          console.log('✅ Access Token이 저장되었습니다.')
-          console.log('📌 토큰 타입:', response.data.tokenType)
-          console.log('⏰ Access Token 만료:', response.data.expiresIn, '초 (', response.data.expiresIn / 60, '분)')
-          console.log('🍪 Refresh Token은 httpOnly 쿠키에 저장됨')
+          console.log('Access Token이 저장되었습니다.')
+          console.log('토큰 타입:', response.data.tokenType)
+          console.log('Access Token 만료:', response.data.expiresIn, '초 (', response.data.expiresIn / 60, '분)')
+          console.log('Refresh Token은 httpOnly 쿠키에 저장됨')
         } else {
-          console.error('❌ Access Token이 응답에 없습니다!')
+          console.error('Access Token이 응답에 없습니다!')
           throw new Error('Access Token을 받지 못했습니다.')
         }
         
@@ -69,9 +69,9 @@ export const useAuthStore = defineStore('auth', () => {
       // 서버에 로그아웃 요청 (토큰을 블랙리스트에 추가)
       // axios 인터셉터가 자동으로 Authorization: Bearer {token} 헤더 추가
       await axios.post('/user/logout')
-      console.log('✅ 서버 로그아웃 성공 - 토큰이 블랙리스트에 추가됨')
+      console.log('서버 로그아웃 성공 - 토큰이 블랙리스트에 추가됨')
     } catch (error) {
-      console.error('❌ 서버 로그아웃 오류:', error)
+      console.error('서버 로그아웃 오류:', error)
       // 서버 요청 실패해도 클라이언트는 로그아웃 처리
     } finally {
       // 클라이언트에서 상태 초기화 (항상 실행)
@@ -79,20 +79,20 @@ export const useAuthStore = defineStore('auth', () => {
       localStorage.removeItem('userInfo')        // localStorage에서 사용자 정보 삭제
       isLoggedIn.value = false                   // 로그인 상태 false
       userInfo.value = null                      // 사용자 정보 초기화
-      console.log('✅ 클라이언트 로그아웃 완료')
+      console.log('클라이언트 로그아웃 완료')
     }
   }
 
   const checkAuthStatus = async () => {
     const token = getToken()
     if (!token) {
-      console.log('❌ 토큰 없음 - 로그인 필요')
+      console.log('토큰 없음 - 로그인 필요')
       isLoggedIn.value = false
       userInfo.value = null
       return false
     }
 
-    console.log('✅ 토큰 있음 - 로그인 상태 복원')
+    console.log('토큰 있음 - 로그인 상태 복원')
     
     // JWT 토큰이 있으면 로그인 상태로 설정
     // 실제 사용자 정보는 필요할 때 API로 가져옴
@@ -103,7 +103,7 @@ export const useAuthStore = defineStore('auth', () => {
     if (savedUserInfo) {
       try {
         userInfo.value = JSON.parse(savedUserInfo)
-        console.log('👤 사용자 정보 복원:', userInfo.value)
+        console.log('사용자 정보 복원:', userInfo.value)
       } catch (e) {
         console.error('사용자 정보 파싱 오류:', e)
       }
@@ -119,16 +119,68 @@ export const useAuthStore = defineStore('auth', () => {
     userInfo.value = null
   }
 
+  // OAuth 리다이렉트 경로 저장
+  const oauthRedirectPath = ref(null)
+  
+  const setOAuthRedirect = (path) => {
+    oauthRedirectPath.value = path
+    console.log('OAuth 리다이렉트 경로 저장:', path)
+  }
+  
+  const getOAuthRedirect = () => {
+    const path = oauthRedirectPath.value
+    oauthRedirectPath.value = null // 사용 후 초기화
+    return path
+  }
+
   // 토큰 갱신 (Refresh Token 사용)
   const refreshToken = async () => {
     try {
       const newAccessToken = await refreshAccessToken()
-      console.log('✅ 스토어: Access Token 갱신 완료')
+      console.log('스토어: Access Token 갱신 완료')
       return newAccessToken
     } catch (error) {
-      console.error('❌ 스토어: Access Token 갱신 실패')
+      console.error('스토어: Access Token 갱신 실패')
       clearAuth()
       throw error
+    }
+  }
+
+  // 카카오 로그인 (OAuth 인증 코드 처리)
+  const kakaoLogin = async (kakaoData) => {
+    try {
+      isLoading.value = true
+      const response = await axios.post('/user/kakao-login', kakaoData)
+      
+      if (response.data && response.data.accessToken) {
+        // 토큰 저장
+        localStorage.setItem('accessToken', response.data.accessToken)
+        if (response.data.refreshToken) {
+          localStorage.setItem('refreshToken', response.data.refreshToken)
+        }
+        
+        // 사용자 정보 저장
+        userInfo.value = response.data.user || {
+          id: response.data.userId,
+          nickname: response.data.nickname || '카카오 사용자',
+          email: response.data.email || '',
+          profileImage: response.data.profileImage || ''
+        }
+        
+        // 사용자 정보를 localStorage에 저장
+        localStorage.setItem('userInfo', JSON.stringify(userInfo.value))
+        
+        isLoggedIn.value = true
+        
+        return { success: true, data: response.data }
+      } else {
+        throw new Error('카카오 로그인 응답 데이터가 올바르지 않습니다.')
+      }
+    } catch (error) {
+      console.error('카카오 로그인 에러:', error)
+      throw error
+    } finally {
+      isLoading.value = false
     }
   }
 
@@ -147,7 +199,10 @@ export const useAuthStore = defineStore('auth', () => {
     logout,
     checkAuthStatus,
     clearAuth,
-    refreshToken  // 토큰 갱신 함수 추가
+    refreshToken,  // 토큰 갱신 함수 추가
+    kakaoLogin,     // 카카오 로그인 함수 추가
+    setOAuthRedirect, // OAuth 리다이렉트 경로 저장
+    getOAuthRedirect  // OAuth 리다이렉트 경로 가져오기
   }
 })
 

--- a/src/views/LoginRedirectView.vue
+++ b/src/views/LoginRedirectView.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+    <div class="max-w-md w-full bg-white dark:bg-gray-800 shadow-xl rounded-2xl p-8 text-center">
+      <!-- 로딩 스피너 -->
+      <div v-if="isLoading" class="space-y-6">
+        <div class="flex justify-center">
+          <div class="animate-spin rounded-full h-16 w-16 border-b-2 border-yellow-500"></div>
+        </div>
+        <div>
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+            {{ currentProvider }} 로그인 처리 중...
+          </h2>
+          <p class="text-gray-600 dark:text-gray-400">
+            잠시만 기다려주세요
+          </p>
+        </div>
+      </div>
+
+      <!-- 성공 메시지 -->
+      <div v-else-if="isSuccess" class="space-y-6">
+        <div class="flex justify-center">
+          <div class="w-16 h-16 bg-green-100 dark:bg-green-900 rounded-full flex items-center justify-center">
+            <svg class="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+            </svg>
+          </div>
+        </div>
+        <div>
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+            로그인 성공!
+          </h2>
+          <p class="text-gray-600 dark:text-gray-400">
+            {{ redirectMessage }}
+          </p>
+        </div>
+      </div>
+
+      <!-- 에러 메시지 -->
+      <div v-else-if="isError" class="space-y-6">
+        <div class="flex justify-center">
+          <div class="w-16 h-16 bg-red-100 dark:bg-red-900 rounded-full flex items-center justify-center">
+            <svg class="w-8 h-8 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+          </div>
+        </div>
+        <div>
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+            로그인 실패
+          </h2>
+          <p class="text-gray-600 dark:text-gray-400">
+            {{ errorMessage }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth.js'
+import { setToken, getToken } from '../utils/auth.js'
+import axios from 'axios'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+const isLoading = ref(true)
+const isSuccess = ref(false)
+const isError = ref(false)
+const errorMessage = ref('')
+const redirectMessage = ref('')
+const currentProvider = ref('카카오') // 현재 로그인 중인 provider
+
+onMounted(() => {
+  handleSocialCallback()
+})
+
+// 소셜 로그인 콜백 처리 (카카오/구글)
+const handleSocialCallback = async () => {
+  const code = route.query.code
+  const accessToken = route.query.accessToken
+  const expiresIn = route.query.expiresIn
+  const isNewUser = route.query.isNewUser
+
+  // 디버깅을 위한 URL 파라미터 확인
+  console.log('🔍 소셜 로그인 콜백 파라미터:')
+  console.log('📍 현재 URL:', window.location.href)
+  console.log('📍 현재 경로:', route.path)
+  console.log('🔑 code:', code)
+  console.log('🎫 accessToken:', accessToken)
+  console.log('⏰ expiresIn:', expiresIn)
+  console.log('👤 isNewUser:', isNewUser)
+  console.log('🌐 전체 query:', route.query)
+  
+  console.log('🔐 토큰 확인:', getToken())
+  console.log('🔐 localStorage accessToken:', localStorage.getItem('accessToken'))
+
+  // 카카오, 구글, 네이버 로그인인 경우 (code가 있는 경우)
+  if (code) {
+    // provider 확인 (URL 경로 또는 추가 로직으로 판단)
+    const path = route.path
+    const href = window.location.href
+    let provider = 'kakao' // 기본값
+    
+    if (path.includes('google') || href.includes('google')) {
+      provider = 'google'
+      currentProvider.value = '구글'
+    } else if (path.includes('naver') || href.includes('naver')) {
+      provider = 'naver'
+      currentProvider.value = '네이버'
+      // 네이버는 state 파라미터가 있음
+      const state = route.query.state
+      const savedState = localStorage.getItem('naver_oauth_state')
+      
+      // state 검증
+      if (!state || state !== savedState) {
+        throw new Error('네이버 로그인 state 검증 실패')
+      }
+      localStorage.removeItem('naver_oauth_state')
+    } else {
+      currentProvider.value = '카카오'
+    }
+    
+    console.log(`✅ ${provider} 로그인 감지 - code 처리`)
+    
+    try {
+      // 소셜 로그인 API 호출
+      let apiEndpoint
+      if (provider === 'google') {
+        apiEndpoint = 'http://localhost:8080/oauth/google/login'
+      } else if (provider === 'naver') {
+        apiEndpoint = 'http://localhost:8080/oauth/naver/login'
+      } else {
+        apiEndpoint = 'http://localhost:8080/oauth/kakao/login'
+      }
+      
+      console.log(`📤 백엔드로 ${provider} 로그인 요청 전송...`)
+      console.log('📍 요청 URL:', apiEndpoint)
+      console.log('🔑 전송할 code:', code)
+      
+      const response = await axios.get(apiEndpoint, {
+        params: { code },
+        withCredentials: true // 쿠키로 refreshToken을 받기 위해 필요
+      })
+      
+      console.log(`✅ ${provider} 로그인 API 응답 수신!`)
+      console.log('📋 전체 응답 객체:', response)
+      console.log('📋 응답 상태 코드:', response.status)
+      console.log('📋 응답 헤더:', response.headers)
+      console.log('📋 응답 데이터:', response.data)
+      
+      // 백엔드 응답 구조: { success, message, token, tokenType, expiresIn, user, timestamp }
+      const { token, user } = response.data
+      
+      console.log('📦 파싱된 데이터:')
+      console.log('- token (accessToken):', token)
+      console.log('- user:', user)
+      
+      // 토큰 저장 (백엔드에서는 refreshToken을 쿠키로 보냄)
+      if (token) {
+        setToken(token)
+      }
+      
+      // 사용자 정보 저장 (백엔드 user 객체 구조에 맞춤)
+      const userInfo = {
+        id: user.userId || user.id,
+        name: user.name,
+        email: user.email,
+        profileImage: user.profileImageUrl || user.profileImage,
+        address: user.address,
+        role: user.role
+      }
+      localStorage.setItem('userInfo', JSON.stringify(userInfo))
+      
+      // auth 스토어 상태 업데이트
+      authStore.userInfo = userInfo
+      authStore.isLoggedIn = true
+      
+      // 성공 처리
+      isLoading.value = false
+      isSuccess.value = true
+      console.log(`✅ ${provider} 로그인 성공!`)
+      
+      // 사용자 정보 완성도 확인 (address가 null이거나 비어있으면 추가 정보 필요)
+      const needsAdditionalInfo = !userInfo.address || userInfo.address === null
+      
+      // 리다이렉트 메시지 설정
+      redirectMessage.value = needsAdditionalInfo 
+        ? '추가 정보 입력 페이지로 이동합니다' 
+        : '메인 페이지로 이동합니다'
+      
+      // 2초 후 조건부 리다이렉트
+      setTimeout(() => {
+        if (needsAdditionalInfo) {
+          console.log('추가 정보가 필요합니다. 추가 정보 입력 페이지로 이동합니다.')
+          router.push('/social-signup')
+        } else {
+          console.log('사용자 정보가 완전합니다. 메인 페이지로 이동합니다.')
+          router.push('/')
+        }
+      }, 2000)
+    } catch (error) {
+      console.error(`🚨 ${provider} 로그인 처리 오류!`)
+      console.error('📊 에러 객체 전체:', error)
+      console.error('📊 에러 상세 정보:')
+      console.error('- 에러 메시지:', error.message)
+      console.error('- 에러 코드:', error.code)
+      console.error('- 에러 이름:', error.name)
+      console.error('- 에러 스택:', error.stack)
+      
+      if (error.response) {
+        // 서버가 응답을 반환했지만 에러 상태 코드
+        console.error('📊 응답 에러 정보:')
+        console.error('- 응답 상태:', error.response.status)
+        console.error('- 응답 상태 텍스트:', error.response.statusText)
+        console.error('- 응답 헤더:', error.response.headers)
+        console.error('- 응답 데이터:', error.response.data)
+      } else if (error.request) {
+        // 요청은 했지만 응답을 받지 못함
+        console.error('📊 요청 에러 정보:')
+        console.error('- 요청 객체:', error.request)
+        console.error('- 요청 URL:', error.config?.url)
+      }
+      
+      console.error('📋 요청 설정 정보:')
+      console.error('- 요청 URL:', error.config?.url)
+      console.error('- 요청 메서드:', error.config?.method)
+      console.error('- 요청 파라미터:', error.config?.params)
+      console.error('- 요청 데이터:', error.config?.data)
+      console.error('- 요청 헤더:', error.config?.headers)
+      
+      // 에러 처리
+      isLoading.value = false
+      isError.value = true
+      errorMessage.value = error.response?.data?.error || error.response?.data?.message || error.message || `${provider} 로그인 중 오류가 발생했습니다.`
+      
+      // 에러 발생 시 자동으로 /login으로 리다이렉트하지 않음 - 콘솔에서 확인 가능
+      console.error('⚠️ 에러 발생으로 인해 페이지가 유지됩니다. 콘솔을 확인하세요.')
+    }
+  } else {
+    // 인증 정보가 없는 경우
+    console.error('❌ 인증 정보를 받을 수 없습니다.')
+    console.log('🔍 받은 파라미터:', route.query)
+    isLoading.value = false
+    isError.value = true
+    errorMessage.value = '인증 정보를 받을 수 없습니다.'
+  }
+}
+
+</script>
+
+<style scoped>
+/* 스타일 제거 */
+</style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
+import axios from 'axios'
 
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
 const userId = ref('')
 const password = ref('')
@@ -61,6 +63,70 @@ const handleLogin = async () => {
 const goToSignup = () => {
   router.push('/signup')
 }
+
+// 소셜 로그인
+const isKakaoLoading = ref(false)
+const isNaverLoading = ref(false)
+const isGoogleLoading = ref(false)
+
+const handleKakaoLogin = () => {
+  try {
+    isKakaoLoading.value = true
+    loginError.value = ''
+    
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URI}&response_type=code`
+    
+    console.log('카카오 로그인 시작')
+    console.log('이동할 URL:', kakaoAuthUrl)
+    
+    
+    window.location.href = kakaoAuthUrl
+  } catch (err) {
+    console.error('❌ 카카오 로그인 URL 생성 실패:', err)
+    loginError.value = '카카오 로그인을 시작할 수 없습니다.'
+    isKakaoLoading.value = false
+  }
+}
+
+const handleNaverLogin = () => {
+  try {
+    isNaverLoading.value = true
+    loginError.value = ''
+    
+    // state는 CSRF 공격 방지를 위한 랜덤 문자열
+    const state = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
+    localStorage.setItem('naver_oauth_state', state)
+    
+    const naverAuthUrl = `https://nid.naver.com/oauth2.0/authorize?client_id=${import.meta.env.VITE_NAVER_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_NAVER_REDIRECT_URI}&response_type=code&state=${state}`
+    
+    console.log('네이버 로그인 시작')
+    console.log('이동할 URL:', naverAuthUrl)
+    
+    window.location.href = naverAuthUrl
+  } catch (err) {
+    console.error('❌ 네이버 로그인 URL 생성 실패:', err)
+    loginError.value = '네이버 로그인을 시작할 수 없습니다.'
+    isNaverLoading.value = false
+  }
+}
+
+const handleGoogleLogin = () => {
+  try {
+    isGoogleLoading.value = true
+    loginError.value = ''
+    
+    const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_GOOGLE_REDIRECT_URI}&response_type=code&scope=openid email profile`
+    
+    console.log('구글 로그인 시작')
+    console.log('이동할 URL:', googleAuthUrl)
+    
+    window.location.href = googleAuthUrl
+  } catch (err) {
+    console.error('❌ 구글 로그인 URL 생성 실패:', err)
+    loginError.value = '구글 로그인을 시작할 수 없습니다.'
+    isGoogleLoading.value = false
+  }
+}
 </script>
 
 <template>
@@ -80,6 +146,8 @@ const goToSignup = () => {
             <div class="relative">
               <input
                 v-model="userId"
+                id="userId"
+                name="userId"
                 type="text"
                 required
                 class="appearance-none rounded-lg relative block w-full px-4 py-3 border border-gray-300 dark:border-gray-600
@@ -93,6 +161,8 @@ const goToSignup = () => {
             <div class="relative">
               <input
                 v-model="password"
+                id="password"
+                name="password"
                 type="password"
                 required
                 class="appearance-none rounded-lg relative block w-full px-4 py-3 border border-gray-300 dark:border-gray-600
@@ -128,6 +198,65 @@ const goToSignup = () => {
             >
               회원가입
             </button>
+            
+            <!-- 구분선 -->
+            <div class="relative flex items-center my-4">
+              <div class="flex-grow border-t border-gray-300 dark:border-gray-600"></div>
+              <span class="flex-shrink-0 px-3 text-sm text-gray-500 dark:text-gray-400">또는</span>
+              <div class="flex-grow border-t border-gray-300 dark:border-gray-600"></div>
+            </div>
+            
+            <!-- 카카오 로그인 버튼 -->
+            <button
+              type="button"
+              class="kakao-btn"
+              @click="handleKakaoLogin"
+              :disabled="isKakaoLoading"
+            >
+              <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                  fill="#3c1e1e"
+                  d="M12 2C6.48 2 2 5.91 2 10.5c0 3.11 2.4 5.82 5.86 7.12L6.5 22l5.31-3.07c.06 0 .13.01.19.01 5.52 0 10-3.91 10-8.5S17.52 2 12 2z" />
+              </svg>
+              카카오로 로그인
+            </button>
+            
+            <!-- 네이버 로그인 버튼 -->
+            <button
+              type="button"
+              class="naver-btn"
+              @click="handleNaverLogin"
+              :disabled="isNaverLoading"
+            >
+              <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path fill="white" d="M4 4h4l4 7V4h4v16h-4l-4-7v7H4z" />
+              </svg>
+              네이버로 로그인
+            </button>
+            
+            <!-- 구글 로그인 버튼 -->
+            <button
+              type="button"
+              class="google-btn"
+              @click="handleGoogleLogin"
+              :disabled="isGoogleLoading"
+            >
+              <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+                <path
+                  fill="#FFC107"
+                  d="M43.6 20.5H42V20H24v8h11.3c-1.6 4.4-5.8 7.5-11.3 7.5-6.9 0-12.5-5.6-12.5-12.5S17.1 10.5 24 10.5c3.1 0 5.9 1.1 8.1 3.1l5.7-5.7C34.5 4.4 29.6 2.5 24 2.5 12.4 2.5 3 11.9 3 23.5S12.4 44.5 24 44.5c11.6 0 21-9.4 21-21 0-1.5-.2-3-.4-4.5z" />
+                <path
+                  fill="#FF3D00"
+                  d="M6.3 14.7l6.6 4.8c1.8-4.4 5.9-7.5 11.1-7.5 3.1 0 5.9 1.1 8.1 3.1l5.7-5.7C34.5 4.4 29.6 2.5 24 2.5 15.2 2.5 7.5 7.8 3.6 15.1z" />
+                <path
+                  fill="#4CAF50"
+                  d="M24 44.5c5.4 0 10.3-2.1 14-5.5l-6.5-5.4c-2.1 1.5-4.8 2.4-7.5 2.4-5.5 0-10.2-3.6-11.8-8.5H6.3c2.4 7.1 9.2 12 17.7 12z" />
+                <path
+                  fill="#1976D2"
+                  d="M43.6 20.5H42V20H24v8h11.3c-.7 2-1.9 3.8-3.4 5.2l.1.1 6.5 5.4c-1.8 1.7-4 3-6.4 3.8l.3.3c7-6.4 11.1-15.2 11.1-25.3 0-1.5-.2-3-.4-4.5z" />
+              </svg>
+              구글로 로그인
+            </button>
           </div>
           
           <p v-if="loginError" class="mt-2 text-sm text-red-500 text-center">
@@ -154,6 +283,64 @@ const goToSignup = () => {
     -webkit-text-fill-color: white;
     transition: background-color 5000s ease-in-out 0s;
   }
+}
+
+/* 소셜 로그인 버튼 공통 스타일 */
+.kakao-btn, .naver-btn, .google-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-weight: 500;
+  transition: all 0.2s;
+  border: none;
+  cursor: pointer;
+}
+
+.kakao-btn {
+  background-color: #FEE500;
+  color: #3c1e1e;
+}
+
+.kakao-btn:hover:not(:disabled) {
+  background-color: #FDD835;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.naver-btn {
+  background-color: #03C75A;
+  color: white;
+}
+
+.naver-btn:hover:not(:disabled) {
+  background-color: #02b851;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.google-btn {
+  background-color: #fff;
+  color: #757575;
+  border: 1px solid #dadce0;
+}
+
+.google-btn:hover:not(:disabled) {
+  background-color: #f8f9fa;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.kakao-btn:disabled, .naver-btn:disabled, .google-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.social-icon {
+  width: 24px;
+  height: 24px;
 }
 </style>
 

--- a/src/views/SocialSignupView.vue
+++ b/src/views/SocialSignupView.vue
@@ -1,0 +1,238 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
+    <div class="max-w-md w-full bg-white dark:bg-gray-800 shadow-xl rounded-2xl p-8">
+      <div class="space-y-8">
+        <div>
+          <h1 class="text-center text-4xl font-bold text-gray-900 dark:text-white mb-2">
+            추가 정보 입력
+          </h1>
+          <p class="text-center text-sm text-gray-500 dark:text-gray-400">
+            서비스 이용을 위해 추가 정보를 입력해주세요
+          </p>
+        </div>
+        
+        <form class="space-y-6" @submit.prevent="handleSubmit">
+          <div class="space-y-4">
+            <!-- 생년월일 -->
+            <div class="relative">
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">생년월일</label>
+              <input
+                v-model="formData.birthDate"
+                type="text"
+                required
+                class="appearance-none rounded-lg relative block w-full px-4 py-3 border border-gray-300 dark:border-gray-600
+                       placeholder-gray-500 text-gray-900 dark:text-white
+                       focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500
+                       dark:bg-gray-700 dark:placeholder-gray-400
+                       transition-colors duration-200"
+                placeholder="YYYY/MM/DD"
+              />
+            </div>
+            
+            <!-- 주소 -->
+            <div class="relative">
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">주소</label>
+              
+              <!-- 우편번호 -->
+              <div class="flex gap-2 mb-2">
+                <input
+                  v-model="postcode"
+                  type="text"
+                  readonly
+                  placeholder="우편번호"
+                  class="appearance-none rounded-lg relative block w-32 px-4 py-3 border border-gray-300 dark:border-gray-600
+                         placeholder-gray-500 text-gray-900 dark:text-white
+                         focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500
+                         dark:bg-gray-700 dark:placeholder-gray-400
+                         transition-colors duration-200
+                         cursor-not-allowed bg-gray-50 dark:bg-gray-600"
+                />
+                <button
+                  type="button"
+                  @click="openPostcode"
+                  class="px-4 py-3 whitespace-nowrap rounded-lg text-sm font-medium
+                         text-white bg-orange-500 hover:bg-orange-600
+                         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500
+                         transition-colors duration-200"
+                >
+                  주소 찾기
+                </button>
+              </div>
+              
+              <!-- 도로명 주소 -->
+              <input
+                v-model="roadAddress"
+                type="text"
+                readonly
+                required
+                placeholder="도로명 주소"
+                class="appearance-none rounded-lg relative block w-full px-4 py-3 border border-gray-300 dark:border-gray-600
+                       placeholder-gray-500 text-gray-900 dark:text-white mb-2
+                       focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500
+                       dark:bg-gray-700 dark:placeholder-gray-400
+                       transition-colors duration-200
+                       cursor-not-allowed bg-gray-50 dark:bg-gray-600"
+              />
+              
+              <!-- 상세 주소 -->
+              <input
+                id="detailAddress"
+                v-model="detailAddress"
+                @input="updateFullAddress"
+                type="text"
+                placeholder="상세 주소 (동, 호수 등)"
+                class="appearance-none rounded-lg relative block w-full px-4 py-3 border border-gray-300 dark:border-gray-600
+                       placeholder-gray-500 text-gray-900 dark:text-white
+                       focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500
+                       dark:bg-gray-700 dark:placeholder-gray-400
+                       transition-colors duration-200"
+              />
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <button
+              type="submit"
+              :disabled="isLoading"
+              class="group relative w-full flex justify-center py-3 px-4 border border-transparent
+                     text-sm font-medium rounded-lg text-white bg-orange-500 hover:bg-orange-600
+                     focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500
+                     transition-colors duration-200
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {{ isLoading ? '처리 중...' : '완료' }}
+            </button>
+          </div>
+          
+          <p v-if="errorMessage" class="mt-2 text-sm text-red-500 text-center">
+            {{ errorMessage }}
+          </p>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth.js'
+import axios from 'axios'
+
+const router = useRouter()
+const authStore = useAuthStore()
+const isLoading = ref(false)
+const errorMessage = ref('')
+
+const formData = ref({
+  birthDate: '',
+  address: '' // 전체 주소 (서버 전송용)
+})
+
+// 주소 관련 상태
+const postcode = ref('') // 우편번호
+const roadAddress = ref('') // 도로명 주소
+const jibunAddress = ref('') // 지번 주소
+const detailAddress = ref('') // 상세 주소
+const extraAddress = ref('') // 참고 항목
+
+onMounted(() => {
+  // 소셜 로그인 정보가 없으면 로그인 페이지로 리다이렉트
+  const token = localStorage.getItem('jwt_token')
+  if (!token) {
+    router.push('/login')
+  }
+})
+
+
+// 카카오 우편번호 API 호출
+const openPostcode = () => {
+  new window.daum.Postcode({
+    oncomplete: function(data) {
+      // 도로명 주소 변수
+      let fullRoadAddr = data.roadAddress
+      let extraRoadAddr = ''
+
+      // 건물명이 있고, 공동주택일 경우 추가
+      if (data.buildingName !== '' && data.apartment === 'Y') {
+        extraRoadAddr += (extraRoadAddr !== '' ? ', ' + data.buildingName : data.buildingName)
+      }
+      
+      // 표시할 참고항목이 있을 경우, 괄호까지 추가한 문자열 생성
+      if (extraRoadAddr !== '') {
+        extraRoadAddr = ' (' + extraRoadAddr + ')'
+      }
+
+      // 우편번호와 주소 정보를 해당 필드에 입력
+      postcode.value = data.zonecode
+      roadAddress.value = fullRoadAddr
+      jibunAddress.value = data.jibunAddress
+      extraAddress.value = extraRoadAddr
+      
+      // 전체 주소 조합 (서버 전송용)
+      formData.value.address = fullRoadAddr + extraRoadAddr
+      
+      // 상세주소 입력 필드로 포커스 이동
+      document.getElementById('detailAddress')?.focus()
+    }
+  }).open()
+}
+
+// 상세주소 입력 시 전체 주소 업데이트
+const updateFullAddress = () => {
+  if (roadAddress.value) {
+    formData.value.address = roadAddress.value + (extraAddress.value || '') + (detailAddress.value ? ', ' + detailAddress.value : '')
+  }
+}
+
+const handleSubmit = async () => {
+  try {
+    isLoading.value = true
+    errorMessage.value = ''
+
+    // 백엔드에 추가 정보 전송
+    const response = await axios.post('/user/social/profile', {
+      birthDate: formData.value.birthDate,
+      address: formData.value.address
+    })
+
+    if (response.data.success) {
+      // 사용자 정보 업데이트
+      if (response.data.user) {
+        localStorage.setItem('userInfo', JSON.stringify(response.data.user))
+        // auth 스토어의 사용자 정보도 업데이트
+        authStore.userInfo = response.data.user
+        authStore.isLoggedIn = true
+      }
+      
+      // 성공 시 메인 페이지로 이동
+      router.push('/')
+    } else {
+      throw new Error(response.data.message || '추가 정보 저장에 실패했습니다.')
+    }
+  } catch (error) {
+    console.error('추가 정보 저장 오류:', error)
+    errorMessage.value = error.response?.data?.message || '오류가 발생했습니다.'
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.appearance-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+/* 다크모드에서 input autofill 스타일 수정 */
+@media (prefers-color-scheme: dark) {
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus {
+    -webkit-box-shadow: 0 0 0px 1000px #374151 inset;
+    -webkit-text-fill-color: white;
+    transition: background-color 5000s ease-in-out 0s;
+  }
+}
+</style>


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 주요 변경 사항
> 소셜 로그인 통합 구현 및 UI 개선
- 카카오, 구글, 네이버 로그인을 통일된 방식으로 구현
- 각 provider별 개별 인증 URL 생성 및 콜백 처리
- 로그인 처리 중 화면에 provider별 동적 메시지 표시
- 소셜 로그인 공통 처리 함수 제거 및 개별 함수로 분리

---

## 🛠 작업 상세 내용
| 항목 | 내용 |
|------|------|
| 구현 기능 | 소셜 로그인 통합 처리 (카카오, 구글, 네이버) |
| 추가 패키지 | 없음 (기존 axios 사용) |
| 수정한 파일 | `src/views/LoginView.vue, src/views/LoginRedirectView.vue, src/router/index.js` |

---

## ✅ 체크리스트
- [x] 기능이 정상 동작함
- [x] eslint / prettier 적용됨
- [x] 테스트 또는 콘솔 확인 완료
- [x] PR 설명을 모두 작성함
- [ ] 리뷰어 지정함



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카카오, 네이버, 구글을 통한 소셜 로그인 추가
  * 소셜 로그인 후 추가 정보(생년월일, 주소) 입력 화면 추가
  * 로그인 페이지에 소셜 로그인 버튼 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->